### PR TITLE
Remove PropTypes dependency from ESM rollup

### DIFF
--- a/src/components/Elements.js
+++ b/src/components/Elements.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint-disable react/forbid-prop-types */
 import React, {useContext, useMemo, useState} from 'react';
-import PropTypes from 'prop-types';
+// import PropTypes from 'prop-types';
 
 import isEqual from '../utils/isEqual';
 import usePrevious from '../utils/usePrevious';
@@ -117,11 +117,11 @@ export const Elements = ({stripe: rawStripe, options, children}: Props) => {
   );
 };
 
-Elements.propTypes = {
-  stripe: PropTypes.any,
-  children: PropTypes.node,
-  options: PropTypes.object,
-};
+// Elements.propTypes = {
+//   stripe: PropTypes.any,
+//   children: PropTypes.node,
+//   options: PropTypes.object,
+// };
 
 export const useElementsContextWithUseCase = (useCaseMessage: string) => {
   const ctx = useContext(ElementsContext);
@@ -152,6 +152,6 @@ export const ElementsConsumer = ({
   return children(ctx);
 };
 
-ElementsConsumer.propTypes = {
-  children: PropTypes.func.isRequired,
-};
+// ElementsConsumer.propTypes = {
+//   children: PropTypes.func.isRequired,
+// };

--- a/src/components/createElementComponent.js
+++ b/src/components/createElementComponent.js
@@ -1,7 +1,7 @@
 // @flow
 /* eslint-disable react/forbid-prop-types */
 import React, {useRef, useEffect, useLayoutEffect} from 'react';
-import PropTypes from 'prop-types';
+// import PropTypes from 'prop-types';
 import {useElementsContextWithUseCase} from './Elements';
 import isEqual from '../utils/isEqual';
 
@@ -122,16 +122,16 @@ const createElementComponent = (type: string) => {
     return <div id={id} className={className} ref={domNode} />;
   };
 
-  Element.propTypes = {
-    id: PropTypes.string,
-    className: PropTypes.string,
-    onChange: PropTypes.func,
-    onBlur: PropTypes.func,
-    onFocus: PropTypes.func,
-    onReady: PropTypes.func,
-    onClick: PropTypes.func,
-    options: PropTypes.object,
-  };
+  // Element.propTypes = {
+  //   id: PropTypes.string,
+  //   className: PropTypes.string,
+  //   onChange: PropTypes.func,
+  //   onBlur: PropTypes.func,
+  //   onFocus: PropTypes.func,
+  //   onReady: PropTypes.func,
+  //   onClick: PropTypes.func,
+  //   options: PropTypes.object,
+  // };
 
   Element.defaultProps = {
     onChange: noop,


### PR DESCRIPTION
### Summary & motivation

removed prop_types from the components, allowing a rollup to ESM with out dependency errors
